### PR TITLE
Add support for specifying colors and stroke patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,9 @@ version = "0.1.0"
 dependencies = [
  "handlebars",
  "knuffel",
+ "lazy_static",
  "miette",
+ "regex",
  "serde",
  "skia-safe",
  "syn 2.0.23",
@@ -693,9 +695,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -704,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ serde = { version = "1.0.166", features = ["derive"] }
 syn = "2.0.21"
 skia-safe = { version = "0.63.0", features = ["textlayout"] }
 thiserror = "1.0.43"
+lazy_static = "1.4.0"
+regex = "1.9.1"

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -12,7 +12,15 @@ geometry {
     cut 37
     safe 75
 }
-rectangle x=100 y=100 w=625 h=925
+background {
+    solid "white"
+}
+rectangle x=100 y=100 w=625 h=925 {
+    stroke 5 "black" {
+        pattern "dotted"
+    }
+    solid "rgb(128, 255, 128)"
+}
 text "Hello from {{name}}
 
 version {{version}}" {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -4,6 +4,8 @@ use handlebars::Context;
 use miette::IntoDiagnostic;
 use serde::Serialize;
 
+use crate::layout::model::styles::color::Color;
+
 pub struct Card {
     pub id: String,
     fields: HashMap<String, String>,
@@ -17,6 +19,25 @@ impl Card {
 
     pub fn fields_mut(&mut self) -> &mut HashMap<String, String> {
         &mut self.fields
+    }
+
+    pub fn color_named(&self, color_name: &str) -> Option<Color> {
+        match color_name {
+            // TODO: find a better place to store builtin colors
+            "transparent" => Some(Color::RGBA(0x00, 0x00, 0x00, 0x00)),
+            "black" => Some(Color::RGBA(0x00, 0x00, 0x00, 0xff)),
+            "dark gray" => Some(Color::RGBA(0x44, 0x44, 0x44, 0xff)),
+            "gray" => Some(Color::RGBA(0x88, 0x88, 0x88, 0xff)),
+            "light gray" => Some(Color::RGBA(0xcc, 0xcc, 0xcc, 0xff)),
+            "white" => Some(Color::RGBA(0xff, 0xff, 0xff, 0xff)),
+            "red" => Some(Color::RGBA(0xff, 0x00, 0x00, 0xff)),
+            "green" => Some(Color::RGBA(0x00, 0xff, 0x00, 0xff)),
+            "blue" => Some(Color::RGBA(0x00, 0x00, 0xff, 0xff)),
+            "yellow" => Some(Color::RGBA(0xff, 0xff, 0x00, 0xff)),
+            "cyan" => Some(Color::RGBA(0x00, 0xff, 0xff, 0xff)),
+            "magenta" => Some(Color::RGBA(0xff, 0x00, 0xff, 0xff)),
+            _ => None, // TODO: actually try to look this up in project state
+        }
     }
 }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -14,9 +14,9 @@ pub use model::{
     },
     styles::{
         PathStyle, TextStyle,
-        fill::Fill,
         font::Font,
         only_if::{ OnlyIf, OnlyIfOperator },
+        solid::Solid,
         stroke::Stroke,
     },
 };

--- a/src/layout/model/mod.rs
+++ b/src/layout/model/mod.rs
@@ -14,7 +14,7 @@ pub struct Layout {
 
 #[cfg(test)]
 mod tests {
-    use crate::layout::{model::{geometry::{Insets, Geometry}, elements::{shapes::{Background, Rectangle}, Element, text::Text, Frame, containers::Box}, styles::{fill::Fill, PathStyle, only_if::{OnlyIf, OnlyIfOperator}, stroke::Stroke, TextStyle, font::Font}}, templates::TemplateAwareString};
+    use crate::layout::{model::{geometry::{Insets, Geometry}, elements::{shapes::{Background, Rectangle}, Element, text::Text, Frame, containers::Box}, styles::{solid::Solid, PathStyle, only_if::{OnlyIf, OnlyIfOperator}, stroke::{Stroke, DashPattern}, TextStyle, font::Font, color::{ColorRef, Color}}}, templates::TemplateAwareString};
 
     use super::Layout;
 
@@ -26,22 +26,24 @@ mod tests {
         safe 75
     }
     background {
-        fill { type "gradient"; }
+        solid "white"
     }
     rectangle x=1 y=2 w=3 h=4
     rectangle x=5 y=6 w=7 h=8 {
         only-if "some text"
-        stroke 3
-        fill {
-            type "solid"
-        }
+        stroke 3 "black"
+        solid "rgba(110, 120, 130, 255)"
     }
     text "some text" {
         frame x=100 y=200 w=300 h=400
         only-if "some {{other}} text" "in" "xxx" "yyy" "zzz"
     }
     box x=50 y=50 w=100 h=100 {
-        rectangle x=1 y=2 w=3 h=4
+        rectangle x=1 y=2 w=3 h=4 {
+            stroke 2 "black" {
+                pattern "---  .. "
+            }
+        }
         text "some text" {
             frame x=10 y=20 w=30 h=40
             font "Fira Code"
@@ -65,8 +67,8 @@ mod tests {
                 elements: vec![
                     Element::Background(Background {
                         style: vec![
-                            PathStyle::Fill(Fill {
-                                r#type: "gradient".to_string(),
+                            PathStyle::Solid(Solid {
+                                color: ColorRef::Named(TemplateAwareString::new("white".to_string())),
                             }),
                         ],
                     }),
@@ -90,9 +92,11 @@ mod tests {
                             }),
                             PathStyle::Stroke(Stroke {
                                 width: 3,
+                                color: ColorRef::Named(TemplateAwareString::new("black".to_string())),
+                                pattern: DashPattern::Solid,
                             }),
-                            PathStyle::Fill(Fill {
-                                r#type: "solid".to_string(),
+                            PathStyle::Solid(Solid {
+                                color: ColorRef::Static(Color::RGBA(110, 120, 130, 255)),
                             }),
                         ],
                     }),
@@ -127,7 +131,15 @@ mod tests {
                                 y: 2,
                                 w: 3,
                                 h: 4,
-                                style: vec![],
+                                style: vec![
+                                    PathStyle::Stroke(
+                                        Stroke {
+                                            width: 2,
+                                            color: ColorRef::Named(TemplateAwareString::new("black".to_string())),
+                                            pattern: DashPattern::Dashed(vec![9, 2, 2, 1]),
+                                        }
+                                    )
+                                ],
                             }),
                             Element::Text(Text {
                                 contents: TemplateAwareString::new("some text".to_string()),

--- a/src/layout/model/styles/color.rs
+++ b/src/layout/model/styles/color.rs
@@ -1,0 +1,86 @@
+use std::str::FromStr;
+
+use lazy_static::lazy_static;
+use miette::Diagnostic;
+use regex::Regex;
+use thiserror::Error;
+
+use crate::layout::templates::TemplateAwareString;
+
+lazy_static! {
+    static ref RGB_REGEX: Regex = Regex::new(r#"\Argb\(([^,]+),([^,]+),([^,]+)\)\z"#).unwrap();
+    static ref RGBA_REGEX: Regex = Regex::new(r#"\Argba\(([^,]+),([^,]+),([^,]+),([^,]+)\)\z"#).unwrap();
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum ColorRef {
+    Static(Color),
+    Named(TemplateAwareString),
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum Color {
+    RGB(u8, u8, u8),
+    RGBA(u8, u8, u8, u8),
+}
+
+impl FromStr for ColorRef {
+    type Err = ColorParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match RGB_REGEX.captures(s).map(|cap| cap.extract()) {
+            Some((_, [red, green, blue])) =>
+                red
+                    .trim()
+                    .parse::<u8>()
+                    .map_err(|_| ColorParseError::InvalidComponent(red.to_string()))
+                    .and_then(|r|
+                        green
+                            .trim()
+                            .parse::<u8>()
+                            .map_err(|_| ColorParseError::InvalidComponent(green.to_string()))
+                            .and_then(|g|
+                                blue
+                                    .trim()
+                                    .parse::<u8>()
+                                    .map_err(|_| ColorParseError::InvalidComponent(blue.to_string()))
+                                    .map(|b| ColorRef::Static(Color::RGB(r, g, b)))
+                            )
+                    ),
+            None => match RGBA_REGEX.captures(s).map(|cap| cap.extract()) {
+                Some((_, [red, green, blue, alpha])) =>
+                    red
+                        .trim()
+                        .parse::<u8>()
+                        .map_err(|_| ColorParseError::InvalidComponent(red.to_string()))
+                        .and_then(|r|
+                            green
+                                .trim()
+                                .parse::<u8>()
+                                .map_err(|_| ColorParseError::InvalidComponent(green.to_string()))
+                                .and_then(|g|
+                                    blue
+                                        .trim()
+                                        .parse::<u8>()
+                                        .map_err(|_| ColorParseError::InvalidComponent(blue.to_string()))
+                                        .and_then(|b|
+                                            alpha
+                                                .trim()
+                                                .parse::<u8>()
+                                                .map_err(|_| ColorParseError::InvalidComponent(alpha.to_string()))
+                                                .map(|a| ColorRef::Static(Color::RGBA(r, g, b, a)))
+
+                                        )
+                                )
+                        ),
+                None => Ok(ColorRef::Named(TemplateAwareString::new(s.to_string())))
+            }
+        }
+    }
+}
+
+#[derive(Error, Diagnostic, Debug)]
+pub enum ColorParseError {
+    #[error("error when parsing color: invalid rgba component '{0}' (must be an integer in the range 0...255)")]
+    InvalidComponent(String),
+}

--- a/src/layout/model/styles/fill.rs
+++ b/src/layout/model/styles/fill.rs
@@ -1,7 +1,0 @@
-#[derive(knuffel::Decode, PartialEq, Eq, Debug, Clone)]
-pub struct Fill {
-    // TODO: expand definition to support different fill types, and provide
-    //       custom knuffel::Decode to flatten it
-    #[knuffel(child, unwrap(argument))]
-    pub r#type: String,
-}

--- a/src/layout/model/styles/mod.rs
+++ b/src/layout/model/styles/mod.rs
@@ -1,12 +1,13 @@
-pub mod fill;
+pub mod color;
 pub mod font;
 pub mod only_if;
+pub mod solid;
 pub mod stroke;
 
 #[derive(knuffel::Decode, PartialEq, Eq, Debug, Clone)]
 pub enum PathStyle {
     Stroke(stroke::Stroke),
-    Fill(fill::Fill),
+    Solid(solid::Solid),
     OnlyIf(only_if::OnlyIf),
 }
 

--- a/src/layout/model/styles/solid.rs
+++ b/src/layout/model/styles/solid.rs
@@ -1,0 +1,7 @@
+use super::color::ColorRef;
+
+#[derive(knuffel::Decode, PartialEq, Eq, Debug, Clone)]
+pub struct Solid {
+    #[knuffel(argument, str)]
+    pub color: ColorRef,
+}

--- a/src/layout/model/styles/stroke.rs
+++ b/src/layout/model/styles/stroke.rs
@@ -1,6 +1,102 @@
+use std::{str::FromStr};
+
+use miette::{Diagnostic, SourceOffset};
+use thiserror::Error;
+
+use super::color::ColorRef;
+
 #[derive(knuffel::Decode, PartialEq, Eq, Debug, Clone)]
 pub struct Stroke {
-    // TODO: expand defintion, provide custom decoder, add joint style
+    // TODO: expand defintion, add joint style
     #[knuffel(argument)]
     pub width: usize,
+    #[knuffel(argument, str)]
+    pub color: ColorRef,
+    #[knuffel(child, unwrap(argument, str), default)]
+    pub pattern: DashPattern,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum DashPattern {
+    Solid,
+    Dashed(Vec<u8>),
+}
+
+impl Default for DashPattern {
+    fn default() -> Self {
+        DashPattern::Solid
+    }
+}
+
+impl FromStr for DashPattern {
+    type Err = StrokeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "dotted" {
+            return Ok(DashPattern::Dashed(vec![1, 1]))
+        }
+
+        if s == "dashed" {
+            return Ok(DashPattern::Dashed(vec![3, 1]))
+        }
+
+        let mut pattern = vec![];
+        let mut reading_dashes = true;
+        let mut current_segment_length = 0u8;
+
+        for (idx, ch) in s.char_indices() {
+            match ch {
+                '.' => {
+                    if reading_dashes {
+                        current_segment_length += 1;
+                    } else {
+                        pattern.push(current_segment_length);
+                        current_segment_length = 1;
+                        reading_dashes = true;
+                    }
+                },
+                '-' => {
+                    if reading_dashes {
+                        current_segment_length += 3;
+                    } else {
+                        pattern.push(current_segment_length);
+                        current_segment_length = 3;
+                        reading_dashes = true;
+                    }
+                },
+                ' ' => {
+                    if reading_dashes {
+                        pattern.push(current_segment_length);
+                        current_segment_length = 1;
+                        reading_dashes = false;
+                    } else {
+                        current_segment_length += 1;
+                    }
+                },
+                _ => return Err(
+                    StrokeError::InvalidCharacter {
+                        character: ch,
+                        dash_spec: s.to_string(),
+                        offset: idx.into(),
+                    }
+                ),
+            }
+        }
+
+        pattern.push(current_segment_length);
+
+        Ok(DashPattern::Dashed(pattern))
+    }
+}
+
+#[derive(Error, Diagnostic, Debug)]
+pub enum StrokeError {
+    #[error("unexpected '{character}' in dash pattern")]
+    InvalidCharacter {
+        character: char,
+        #[source_code]
+        dash_spec: String,
+        #[label("invalid character")]
+        offset: SourceOffset,
+    },
 }

--- a/src/layout/model/styles/stroke.rs
+++ b/src/layout/model/styles/stroke.rs
@@ -100,3 +100,45 @@ pub enum StrokeError {
         offset: SourceOffset,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::DashPattern;
+
+    #[test]
+    fn it_recognizes_simple_dotted_pattern() -> miette::Result<()> {
+        let test_pattern: DashPattern = "dotted".parse()?;
+
+        assert_eq!(test_pattern, DashPattern::Dashed(vec![1, 1]));
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_recognizes_simple_dashed_pattern() -> miette::Result<()> {
+        let test_pattern: DashPattern = "dashed".parse()?;
+
+        assert_eq!(test_pattern, DashPattern::Dashed(vec![3, 1]));
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_a_complex_pattern() -> miette::Result<()> {
+        let test_pattern: DashPattern = "---   .-.  ... -. .    ".parse()?;
+
+        assert_eq!(test_pattern, DashPattern::Dashed(
+            //   ---  [ ][ ][ ]  .-.  [ ][ ]  ...  [ ]  -.  [ ]  .  [ ][ ][ ][ ]
+            vec![  9,         3,   5,      2,   3,   1,  4,   1, 1,            4]
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_complains_about_invalid_input() -> () {
+        let test_pattern = "not a dash pattern".parse::<DashPattern>();
+
+        assert!(test_pattern.is_err())
+    }
+}

--- a/src/renderer/skia/drawing.rs
+++ b/src/renderer/skia/drawing.rs
@@ -1,12 +1,14 @@
-use skia_safe::{Canvas, Paint, Color4f, IRect, PaintStyle, textlayout::{TextStyle, FontCollection, ParagraphBuilder, ParagraphStyle}, FontMgr, Rect, ClipOp};
+use skia_safe::{Canvas, Paint, Color4f, IRect, PaintStyle, textlayout::{TextStyle, FontCollection, ParagraphBuilder, ParagraphStyle}, FontMgr, Rect, ClipOp, Color as SkiaColor, PathEffect};
 
-use crate::{layout::{Element, Rectangle, Text, Box}, data::Card};
+use crate::{layout::{Element, Rectangle, Text, Box, model::styles::{color::{ColorRef, Color as CardboardColor}, stroke::DashPattern}, PathStyle, Stroke, Solid}, data::Card};
+
+use super::SkiaRendererError;
 
 pub fn draw_elements(card: &Card, elements: &Vec<Element>, canvas: &mut Canvas, frame_width: usize, frame_height: usize) -> Result<(), miette::Error> {
     for element in elements {
         match element {
-            Element::Background(bg) => draw_rect(&bg.to_rect(frame_width, frame_height), canvas)?,
-            Element::Rectangle(rect) => draw_rect(rect, canvas)?,
+            Element::Background(bg) => draw_rect(&bg.to_rect(frame_width, frame_height), card, canvas)?,
+            Element::Rectangle(rect) => draw_rect(rect, card, canvas)?,
             Element::Text(text) => draw_text(text, card, canvas)?,
             Element::Box(bx) => draw_box(card, bx, canvas)?,
         }
@@ -14,14 +16,18 @@ pub fn draw_elements(card: &Card, elements: &Vec<Element>, canvas: &mut Canvas, 
     Ok(())
 }
 
-fn draw_rect(rect: &Rectangle, canvas: &mut Canvas) -> Result<(), miette::Error> {
-    // TODO: this just strokes the rectangle in black.
-    //       We should aggregrate the styles, then do a 2-pass fill then stroke
-    let mut paint = Paint::new(Color4f::new(0.0f32,0.0f32,0.0f32,1.0f32), None);
-    paint.set_style(PaintStyle::Stroke);
-    paint.set_stroke_width(1.0f32);
+fn draw_rect(rect: &Rectangle, card: &Card, canvas: &mut Canvas) -> Result<(), miette::Error> {
+    let (fill, stroke) = compute_path_styles(&rect.style, card)?;
     let irect = IRect::from_xywh(rect.x as i32, rect.y as i32, rect.w as i32, rect.h as i32);
-    canvas.draw_irect(irect, &paint);
+
+    if let Some(fill) = fill {
+        canvas.draw_irect(irect, &fill);
+    }
+
+    if let Some(stroke) = stroke {
+        canvas.draw_irect(irect, &stroke);
+    }
+
     Ok(())
 }
 
@@ -65,4 +71,70 @@ fn draw_box(card: &Card, bx: &Box, canvas: &mut Canvas) -> Result<(), miette::Er
     canvas.restore();
 
     Ok(())
+}
+
+fn resolve_color_ref(card: &Card, color_ref: &ColorRef) -> Result<SkiaColor, miette::Error> {
+    let color = match color_ref {
+        ColorRef::Named(name_template) => {
+            let name = name_template.render(card.try_into()?)?;
+            card.color_named(name.as_str()).ok_or_else(|| SkiaRendererError::InvalidColor(name))
+        },
+        ColorRef::Static(cb_color) => Ok(cb_color.clone()),
+    }.map(|cb_color| match cb_color {
+        CardboardColor::RGB(r, g, b) => SkiaColor::from_rgb(r, g, b),
+        CardboardColor::RGBA(r, g, b, a) => SkiaColor::from_argb(a, r, g, b),
+    });
+
+    Ok(color?)
+}
+
+fn compute_path_styles(styles: &Vec<PathStyle>, card: &Card) -> Result<(Option<Paint>, Option<Paint>), miette::Error> {
+    let mut fill_paint = Paint::new(Into::<Color4f>::into(SkiaColor::TRANSPARENT), None);
+    let mut should_fill = false;
+    let mut stroke_paint = Paint::new(Into::<Color4f>::into(SkiaColor::TRANSPARENT), None);
+    let mut should_stroke = false;
+    let mut should_render_at_all = true;
+    let card_ctx = TryInto::<&handlebars::Context>::try_into(card)?;
+
+    for style in styles {
+        match style {
+            PathStyle::Stroke(Stroke { width, color, pattern }) => {
+                should_stroke = true;
+                stroke_paint.set_style(PaintStyle::Stroke);
+                stroke_paint.set_stroke(true);
+                stroke_paint.set_anti_alias(true);
+                stroke_paint.set_color(resolve_color_ref(card, color)?);
+                stroke_paint.set_stroke_width(*width as f32);
+                match pattern {
+                    DashPattern::Solid => {},
+                    DashPattern::Dashed(segments) => {
+                        let path_effect =
+                            PathEffect::dash(
+                                segments.iter().map(|len| (*len as f32) * (*width as f32)).collect::<Vec<f32>>().as_slice(),
+                                0.0f32
+                            )
+                            .ok_or_else(|| SkiaRendererError::GraphicsError("could not build dash pattern".to_string()))?;
+                        stroke_paint.set_path_effect(path_effect);
+                    }
+                }
+            },
+            PathStyle::Solid(Solid { color }) => {
+                should_fill = true;
+                fill_paint.set_style(PaintStyle::Fill);
+                fill_paint.set_color(resolve_color_ref(card, color)?);
+            },
+            PathStyle::OnlyIf(condition) => {
+                should_render_at_all = should_render_at_all && condition.evaluate(card_ctx)?;
+            }
+        }
+    }
+
+    if should_render_at_all {
+        Ok((
+            if should_fill { Some(fill_paint) } else { None },
+            if should_stroke { Some(stroke_paint) } else { None },
+        ))
+    } else {
+        Ok((None, None))
+    }
 }

--- a/src/renderer/skia/mod.rs
+++ b/src/renderer/skia/mod.rs
@@ -102,6 +102,8 @@ impl Renderer for SkiaRenderer {
 pub enum SkiaRendererError {
     #[error("encountered an error while rendering a card: {0}")]
     GraphicsError(String),
+    #[error("color name '{0}' not found")]
+    InvalidColor(String),
 }
 
 pub struct SkiaCard {


### PR DESCRIPTION
- Add a color model that can handle named color references, including with templates, and static rgb/rgba tuples
- Add a solid fill style that takes a color
- Add a color and dash pattern to the stroke style
- Handle stroke and fill styles when rendering rectangles

Closes #7 

Makes progress on #9 and #6 