### PR TITLE
Add a few ways to factor out common text styles

### DIFF
--- a/examples/projects/sample/default.layout
+++ b/examples/projects/sample/default.layout
@@ -4,6 +4,15 @@ geometry {
     cut 37
     safe 75
 }
+base {
+    text {
+        font family="Palatino"
+        size 8 "pt"
+        foreground "black"
+    }
+}
+
+
 background {
     solid "cutzone"
 }
@@ -14,33 +23,24 @@ rectangle x=37 y=37 w=751 h=1051 {
 
 text "{{name}}" {
     frame x=75 y=75 w=675 h=200
-    font family="Palatino" weight="black"
+    font weight="black"
     size 11 "pt"
     align "center"
-    foreground "black"
 }
 
 text "{{rules}}" {
     frame x=75 y=275 w=675 h=500
-    font family="Palatino"
-    size 8 "pt"
     align "justify"
-    foreground "black"
 }
 
 text "“{{flavor}}”" {
     frame x=75 y=775 w=675 h=100
-    font family="Palatino" style="italic"
-    size 8 "pt"
+    font style="italic"
     align "right"
-    foreground "black"
     only-if "{{flavor}}"
 }
 
 text "card id: {{id}}" {
     frame x=75 y=875 w=675 h=100
-    font family="Courier New"
-    size 8 "pt"
-    align "left"
-    foreground "black"
+    style "card-id"
 }

--- a/examples/projects/sample/fancy.layout
+++ b/examples/projects/sample/fancy.layout
@@ -4,6 +4,15 @@ geometry {
     cut 37
     safe 75
 }
+base {
+    text {
+        font family="Papyrus"
+        size 8 "pt"
+        foreground "black"
+    }
+}
+
+
 background {
     solid "white"
 }
@@ -12,33 +21,24 @@ background {
 
 text "{{name}}" {
     frame x=75 y=75 w=675 h=200
-    font family="Papyrus" weight="black"
+    font weight="black"
     size 11 "pt"
     align "center"
-    foreground "black"
 }
 
 text "{{rules}}" {
     frame x=75 y=275 w=675 h=500
-    font family="Papyrus"
-    size 8 "pt"
     align "justify"
-    foreground "black"
 }
 
 text "“{{flavor}}”" {
     frame x=75 y=775 w=675 h=100
-    font family="Papyrus" style="italic"
-    size 8 "pt"
+    font style="italic"
     align "right"
-    foreground "black"
     only-if "{{flavor}}"
 }
 
 text "card id: {{id}}" {
     frame x=75 y=875 w=675 h=100
-    font family="Courier New"
-    size 8 "pt"
-    align "left"
-    foreground "black"
+    style "card-id"
 }

--- a/examples/projects/sample/images.layout
+++ b/examples/projects/sample/images.layout
@@ -4,6 +4,16 @@ geometry {
     cut 37
     safe 75
 }
+base {
+    text {
+        font family="Optima"
+        size 11 "pt"
+        align "left"
+        foreground "black"
+    }
+}
+
+
 background {
     solid "cutzone"
 }
@@ -14,10 +24,8 @@ rectangle x=37 y=37 w=751 h=1051 {
 
 text "{{name}}" {
     frame x=75 y=75 w=675 h=175
-    font family="Optima" weight="black"
-    size 11 "pt"
+    font weight="black"
     align "center"
-    foreground "black"
 }
 
 
@@ -25,10 +33,6 @@ text "{{name}}" {
 
 text "Scaling: Fit" {
     frame x=75 y=252 w=375 h=123
-    font family="Optima"
-    size 11 "pt"
-    align "left"
-    foreground "black"
 }
 
 image "{{picture}}" {
@@ -45,10 +49,6 @@ rectangle x=450 y=175 w=300 h=200 {
 
 text "Scaling: Fill" {
     frame x=75 y=452 w=375 h=123
-    font family="Optima"
-    size 11 "pt"
-    align "left"
-    foreground "black"
 }
 
 image "{{picture}}" {
@@ -65,10 +65,6 @@ rectangle x=450 y=375 w=300 h=200 {
 
 text "Scaling: Stretch" {
     frame x=75 y=652 w=375 h=123
-    font family="Optima"
-    size 11 "pt"
-    align "left"
-    foreground "black"
 }
 
 image "{{picture}}" {
@@ -85,10 +81,6 @@ rectangle x=450 y=575 w=300 h=200 {
 
 text "Scaling: None" {
     frame x=75 y=852 w=375 h=123
-    font family="Optima"
-    size 11 "pt"
-    align "left"
-    foreground "black"
 }
 
 image "{{picture}}" {

--- a/examples/projects/sample/project.conf
+++ b/examples/projects/sample/project.conf
@@ -4,6 +4,14 @@ pdf-title "cardboard sample project"
 // color "cutzone" "rgb(3,252,152)"
 color "cutzone" "rgba(255,255,255,0)"
 
+text-style "card-id" {
+    font family="Courier New"
+    size 8 "pt"
+    align "left"
+    foreground "white"
+    background "black"
+}
+
 sheet-type "default" units="in" {
     page-size "letter" "landscape"
     card-size "poker"

--- a/examples/version_card.rs
+++ b/examples/version_card.rs
@@ -13,6 +13,13 @@ geometry {
     cut 37
     safe 75
 }
+base {
+    text {
+        font family="Optima" weight="normal"
+        align "center"
+        size 8 "pt"
+    }
+}
 background {
     solid "white"
 }
@@ -24,17 +31,13 @@ rectangle x=100 y=100 w=625 h=925 {
 }
 text "Hello from {{name}}" {
     frame x=150 y=200 w=525 h=100
-    font family="Optima" weight="black"
+    font weight="black"
     size 11 "pt"
-    align "center"
     foreground "rgb(64, 64, 192)"
 }
 
 text "version {{version}}" {
     frame x=150 y=300 w=525 h=625
-    font family="Optima" weight="normal"
-    size 8 "pt"
-    align "center"
 }
 "###;
 

--- a/examples/version_card.rs
+++ b/examples/version_card.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use cardboard::{data::{card::Card, project::Project}, layout::Layout, renderer::{SkiaRenderer, Renderer}};
+use cardboard::{data::{card::Card, project::Project}, layout::model::Layout, renderer::{SkiaRenderer, Renderer}};
 
 const NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
-use crate::layout::model::styles::color::Color;
+use crate::layout::model::styles::{color::Color, TextStyle as LayoutTextStyle};
 
 pub mod colors;
 pub mod sheets;
+pub mod styles;
 pub mod util;
 
 #[derive(knuffel::Decode)]
@@ -18,6 +19,8 @@ pub struct RawConfig {
     pub pdf_keywords: Option<String>,
     #[knuffel(children(name="color"))]
     colors: Vec<colors::ColorDefinition>,
+    #[knuffel(children(name="text-style"))]
+    text_styles: Vec<styles::TextStyle>,
     #[knuffel(children(name="sheet-type"))]
     sheet_types: Vec<sheets::SheetType>,
 }
@@ -31,6 +34,16 @@ impl RawConfig {
         }
 
         Ok(color_map)
+    }
+
+    pub fn get_text_styles(&self) -> HashMap<String, Vec<LayoutTextStyle>> {
+        let mut style_map = HashMap::new();
+
+        for text_style in &self.text_styles {
+            style_map.insert(text_style.name.clone(), text_style.styles.clone());
+        }
+
+        style_map
     }
 
     pub fn get_sheet_layouts(&self) -> miette::Result<HashMap<String, sheets::layout::Sheet>> {

--- a/src/config/styles.rs
+++ b/src/config/styles.rs
@@ -1,0 +1,9 @@
+use crate::layout::model::styles::TextStyle as LayoutTextStyle;
+
+#[derive(knuffel::Decode)]
+pub struct TextStyle {
+    #[knuffel(argument)]
+    pub name: String,
+    #[knuffel(children)]
+    pub styles: Vec<LayoutTextStyle>,
+}

--- a/src/data/globals.rs
+++ b/src/data/globals.rs
@@ -1,6 +1,6 @@
 use std::{sync::OnceLock, collections::HashMap};
 
-use crate::layout::{model::styles::color::Color, Layout};
+use crate::layout::{model::styles::color::Color, model::Layout};
 
 static BUILTIN_LAYOUTS: OnceLock<HashMap<&'static str, Layout>> = OnceLock::new();
 

--- a/src/data/project.rs
+++ b/src/data/project.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path, fs};
 use miette::{Diagnostic, IntoDiagnostic};
 use thiserror::Error;
 
-use crate::{layout::{Layout, model::styles::color::Color}, config::{sheets::layout::Sheet, RawConfig}};
+use crate::{layout::model::{Layout, styles::color::Color}, config::{sheets::layout::Sheet, RawConfig}};
 
 use super::{globals, card::{Card, self}};
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,21 +1,2 @@
 pub mod model;
 pub mod templates;
-
-// re-export model objects
-pub use model::{
-    Layout,
-    geometry::{ Geometry, Insets },
-    elements::{
-        Element, Frame,
-        containers::Box,
-        shapes::{ Background, Rectangle },
-        text::Text,
-    },
-    styles::{
-        PathStyle, TextStyle,
-        font::Font,
-        only_if::{ OnlyIf, OnlyIfOperator },
-        solid::Solid,
-        stroke::Stroke,
-    },
-};

--- a/src/layout/model/elements/text.rs
+++ b/src/layout/model/elements/text.rs
@@ -8,6 +8,8 @@ pub struct Text {
     pub contents: TemplateAwareString,
     #[knuffel(child)]
     pub frame: Frame,
+    #[knuffel(child, unwrap(argument))]
+    pub style: Option<String>,
     #[knuffel(children)]
-    pub style: Vec<TextStyle>,
+    pub inline_styles: Vec<TextStyle>,
 }

--- a/src/layout/model/mod.rs
+++ b/src/layout/model/mod.rs
@@ -8,13 +8,21 @@ pub mod styles;
 pub struct Layout {
     #[knuffel(child)]
     pub geometry: Geometry,
+    #[knuffel(child)]
+    pub base_text: Option<BaseTextStyles>,
     #[knuffel(children)]
     pub elements: Vec<Element>,
 }
 
+#[derive(knuffel::Decode, PartialEq, Eq, Debug)]
+pub struct BaseTextStyles {
+    #[knuffel(children)]
+    pub styles: Vec<styles::TextStyle>,
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::layout::{model::{geometry::{Insets, Geometry}, elements::{shapes::{Background, Rectangle}, Element, text::Text, Frame, containers::Box}, styles::{solid::Solid, PathStyle, only_if::{OnlyIf, OnlyIfOperator}, stroke::{Stroke, DashPattern}, TextStyle, font::{Font, Width, Weight}, color::{ColorRef, Color}}}, templates::TemplateAwareString};
+    use crate::layout::{model::{geometry::{Insets, Geometry}, elements::{shapes::{Background, Rectangle}, Element, text::Text, Frame, containers::Box}, styles::{solid::Solid, PathStyle, only_if::{OnlyIf, OnlyIfOperator}, stroke::{Stroke, DashPattern}, TextStyle, font::{Font, Weight}, color::{ColorRef, Color}, text::{Alignment, Align}}, BaseTextStyles}, templates::TemplateAwareString};
 
     use super::Layout;
 
@@ -25,6 +33,10 @@ mod tests {
         cut 37
         safe 75
         dpi 300
+    }
+    base-text {
+        font weight="light"
+        align "center"
     }
     background {
         solid "white"
@@ -66,6 +78,10 @@ mod tests {
                     safe: Insets::uniform(75),
                     dpi: 300,
                 },
+                base_text: Some(BaseTextStyles { styles: vec![
+                    TextStyle::Font(Font { family: None, weight: Some(Weight::Light), width: None, style: None }),
+                    TextStyle::Align(Align { alignment: Alignment::Center }),
+                ] }),
                 elements: vec![
                     Element::Background(Background {
                         style: vec![
@@ -153,10 +169,10 @@ mod tests {
                                 },
                                 style: vec![
                                     TextStyle::Font(Font {
-                                        family: "Fira Code".to_string(),
-                                        width: Width::Normal,
-                                        weight: Weight::Normal,
-                                        style: "".to_string(),
+                                        family: Some("Fira Code".to_string()),
+                                        width: None,
+                                        weight: None,
+                                        style: None,
                                     }),
                                 ],
                             }),

--- a/src/layout/model/mod.rs
+++ b/src/layout/model/mod.rs
@@ -9,20 +9,38 @@ pub struct Layout {
     #[knuffel(child)]
     pub geometry: Geometry,
     #[knuffel(child)]
-    pub base_text: Option<BaseTextStyles>,
+    pub base: Option<BaseStyles>,
     #[knuffel(children)]
     pub elements: Vec<Element>,
 }
 
 #[derive(knuffel::Decode, PartialEq, Eq, Debug)]
-pub struct BaseTextStyles {
-    #[knuffel(children)]
-    pub styles: Vec<styles::TextStyle>,
+pub struct BaseStyles {
+    #[knuffel(child)]
+    pub path: Option<base_styles::Path>,
+    #[knuffel(child)]
+    pub text: Option<base_styles::Text>,
+}
+
+pub mod base_styles {
+    use super::styles;
+
+    #[derive(knuffel::Decode, PartialEq, Eq, Debug)]
+    pub struct Path {
+        #[knuffel(children)]
+        pub styles: Vec<styles::PathStyle>,
+    }
+
+    #[derive(knuffel::Decode, PartialEq, Eq, Debug)]
+    pub struct Text {
+        #[knuffel(children)]
+        pub styles: Vec<styles::TextStyle>,
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::layout::{model::{geometry::{Insets, Geometry}, elements::{shapes::{Background, Rectangle}, Element, text::Text, Frame, containers::Box}, styles::{solid::Solid, PathStyle, only_if::{OnlyIf, OnlyIfOperator}, stroke::{Stroke, DashPattern}, TextStyle, font::{Font, Weight}, color::{ColorRef, Color}, text::{Alignment, Align}}, BaseTextStyles}, templates::TemplateAwareString};
+    use crate::layout::{model::{geometry::{Insets, Geometry}, elements::{shapes::{Background, Rectangle}, Element, text::Text, Frame, containers::Box}, styles::{solid::Solid, PathStyle, only_if::{OnlyIf, OnlyIfOperator}, stroke::{Stroke, DashPattern}, TextStyle, font::{Font, Weight}, color::{ColorRef, Color}, text::{Alignment, Align}}, base_styles, BaseStyles}, templates::TemplateAwareString};
 
     use super::Layout;
 
@@ -34,9 +52,11 @@ mod tests {
         safe 75
         dpi 300
     }
-    base-text {
-        font weight="light"
-        align "center"
+    base {
+        text {
+            font weight="light"
+            align "center"
+        }
     }
     background {
         solid "white"
@@ -59,6 +79,7 @@ mod tests {
         }
         text "some text" {
             frame x=10 y=20 w=30 h=40
+            style "rules"
             font family="Fira Code"
         }
     }
@@ -78,10 +99,13 @@ mod tests {
                     safe: Insets::uniform(75),
                     dpi: 300,
                 },
-                base_text: Some(BaseTextStyles { styles: vec![
-                    TextStyle::Font(Font { family: None, weight: Some(Weight::Light), width: None, style: None }),
-                    TextStyle::Align(Align { alignment: Alignment::Center }),
-                ] }),
+                base: Some(BaseStyles {
+                    path: None,
+                    text: Some(base_styles::Text { styles: vec![
+                        TextStyle::Font(Font { family: None, weight: Some(Weight::Light), width: None, style: None }),
+                        TextStyle::Align(Align { alignment: Alignment::Center }),
+                    ] }),
+                }),
                 elements: vec![
                     Element::Background(Background {
                         style: vec![
@@ -126,7 +150,8 @@ mod tests {
                             w: 300,
                             h: 400,
                         },
-                        style: vec![
+                        style: None,
+                        inline_styles: vec![
                             TextStyle::OnlyIf(OnlyIf {
                                 left: TemplateAwareString::new("some {{other}} text".to_string()),
                                 op: Some(OnlyIfOperator::In),
@@ -167,7 +192,8 @@ mod tests {
                                     w: 30,
                                     h: 40,
                                 },
-                                style: vec![
+                                style: Some("rules".to_string()),
+                                inline_styles: vec![
                                     TextStyle::Font(Font {
                                         family: Some("Fira Code".to_string()),
                                         width: None,

--- a/src/layout/model/styles/font.rs
+++ b/src/layout/model/styles/font.rs
@@ -2,17 +2,17 @@ use std::{str::FromStr, convert::Infallible};
 
 #[derive(knuffel::Decode, PartialEq, Eq, Debug)]
 pub struct Font {
-    #[knuffel(property, default="serif".to_string())]
-    pub family: String,
-    #[knuffel(property, str, default=Weight::Normal)]
-    pub weight: Weight,
-    #[knuffel(property, str, default=Width::Normal)]
-    pub width: Width,
-    #[knuffel(property, default)]
-    pub style: String,
+    #[knuffel(property)]
+    pub family: Option<String>,
+    #[knuffel(property, str)]
+    pub weight: Option<Weight>,
+    #[knuffel(property, str)]
+    pub width: Option<Width>,
+    #[knuffel(property)]
+    pub style: Option<String>,
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum Width {
     UltraCondensed,
     Condensed,
@@ -40,7 +40,7 @@ impl FromStr for Width {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum Weight {
     Thin,
     ExtraLight,

--- a/src/layout/model/styles/font.rs
+++ b/src/layout/model/styles/font.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, convert::Infallible};
 
-#[derive(knuffel::Decode, PartialEq, Eq, Debug)]
+#[derive(knuffel::Decode, PartialEq, Eq, Debug, Clone)]
 pub struct Font {
     #[knuffel(property)]
     pub family: Option<String>,

--- a/src/layout/model/styles/mod.rs
+++ b/src/layout/model/styles/mod.rs
@@ -12,7 +12,7 @@ pub enum PathStyle {
     OnlyIf(only_if::OnlyIf),
 }
 
-#[derive(knuffel::Decode, PartialEq, Eq, Debug)]
+#[derive(knuffel::Decode, PartialEq, Eq, Debug, Clone)]
 pub enum TextStyle {
     Font(font::Font),
     Size(text::Size),

--- a/src/layout/model/styles/text.rs
+++ b/src/layout/model/styles/text.rs
@@ -1,6 +1,8 @@
 use std::{convert::Infallible, str::FromStr};
 
-use super::color::ColorRef;
+use crate::layout::{OnlyIf, Font};
+
+use super::{color::ColorRef, font, TextStyle};
 
 const POINTS_PER_INCH: f32 = 72.0f32;
 
@@ -60,7 +62,7 @@ pub struct Align {
     pub alignment: Alignment,
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum Alignment {
     Left,
     Center,
@@ -78,6 +80,69 @@ impl FromStr for Alignment {
             "right" => Ok(Alignment::Right),
             "justify" => Ok(Alignment::Justify),
             _ => Ok(Alignment::Left),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct FlatTextStyle<'a> {
+    pub foreground: Option<&'a Foreground>,
+    pub background: Option<&'a Background>,
+    pub size: Option<&'a Size>,
+    pub align: Alignment,
+    pub font_family: Option<&'a str>,
+    pub font_weight: font::Weight,
+    pub font_width: font::Width,
+    pub font_style: Option<&'a str>,
+    pub conditions: Vec<&'a OnlyIf>,
+}
+
+impl<'a> FlatTextStyle<'a> {
+    pub fn apply(&mut self, styles: &'a [TextStyle]) -> () {
+        for style in styles {
+            match style {
+                TextStyle::Font(Font { family, weight, width, style }) => {
+                    self.font_family = family.as_ref().map(|s|s.as_str()).or(self.font_family);
+                    self.font_style = style.as_ref().map(|s|s.as_str()).or(self.font_style);
+                    if let Some(weight) = weight {
+                        self.font_weight = *weight;
+                    }
+                    if let Some(width) = width {
+                        self.font_width = *width;
+                    }
+                },
+                TextStyle::Size(sz) => {
+                    self.size = Some(sz);
+                },
+                TextStyle::Align(Align { alignment }) => {
+                    self.align = *alignment;
+                },
+                TextStyle::Foreground(fg) => {
+                    self.foreground = Some(fg);
+                },
+                TextStyle::Background(bg) => {
+                    self.background = Some(bg);
+                },
+                TextStyle::OnlyIf(cond) => {
+                    self.conditions.push(cond);
+                }
+            }
+        }
+    }
+}
+
+impl<'a> Default for FlatTextStyle<'a> {
+    fn default() -> Self {
+        FlatTextStyle {
+            foreground: None,
+            background: None,
+            size: None,
+            align: Alignment::Left,
+            font_family: None,
+            font_weight: font::Weight::Normal,
+            font_width: font::Width::Normal,
+            font_style: None,
+            conditions: vec![],
         }
     }
 }

--- a/src/layout/model/styles/text.rs
+++ b/src/layout/model/styles/text.rs
@@ -1,6 +1,6 @@
 use std::{convert::Infallible, str::FromStr};
 
-use crate::layout::{OnlyIf, Font};
+use crate::layout::model::styles::{only_if::OnlyIf, font::Font};
 
 use super::{color::ColorRef, font, TextStyle};
 

--- a/src/layout/model/styles/text.rs
+++ b/src/layout/model/styles/text.rs
@@ -18,7 +18,7 @@ pub struct Background {
     pub color: ColorRef,
 }
 
-#[derive(knuffel::Decode, PartialEq, Eq, Debug)]
+#[derive(knuffel::Decode, PartialEq, Eq, Debug, Clone)]
 pub struct Size {
     #[knuffel(argument)]
     pub size: usize,
@@ -56,7 +56,7 @@ impl FromStr for Units {
     }
 }
 
-#[derive(knuffel::Decode, PartialEq, Eq, Debug)]
+#[derive(knuffel::Decode, PartialEq, Eq, Debug, Clone)]
 pub struct Align {
     #[knuffel(argument, str)]
     pub alignment: Alignment,
@@ -85,7 +85,7 @@ impl FromStr for Alignment {
 }
 
 #[derive(Clone)]
-pub struct FlatTextStyle<'a> {
+pub struct ComputedTextStyle<'a> {
     pub foreground: Option<&'a Foreground>,
     pub background: Option<&'a Background>,
     pub size: Option<&'a Size>,
@@ -97,7 +97,7 @@ pub struct FlatTextStyle<'a> {
     pub conditions: Vec<&'a OnlyIf>,
 }
 
-impl<'a> FlatTextStyle<'a> {
+impl<'a> ComputedTextStyle<'a> {
     pub fn apply(&mut self, styles: &'a [TextStyle]) -> () {
         for style in styles {
             match style {
@@ -131,9 +131,9 @@ impl<'a> FlatTextStyle<'a> {
     }
 }
 
-impl<'a> Default for FlatTextStyle<'a> {
+impl<'a> Default for ComputedTextStyle<'a> {
     fn default() -> Self {
-        FlatTextStyle {
+        ComputedTextStyle {
             foreground: None,
             background: None,
             size: None,

--- a/src/renderer/skia/drawing.rs
+++ b/src/renderer/skia/drawing.rs
@@ -1,6 +1,6 @@
 use skia_safe::{Canvas, Paint, Color4f, IRect, PaintStyle, textlayout::{TextStyle as SkTextStyle, FontCollection, ParagraphBuilder, ParagraphStyle}, FontMgr, Rect, ClipOp, Color as SkiaColor, PathEffect, FontStyle, font_style::Slant};
 
-use crate::{layout::{Element, Rectangle, Text, Box, model::{styles::{color::{ColorRef, Color as CardboardColor}, stroke::DashPattern, text::{Foreground, Background as TextBackground, Align, Alignment}, font::{Weight, Width}}, elements::image::{Image, Scale}}, PathStyle, Stroke, Solid, TextStyle, Font}, data::{card::Card, project::{Project}}};
+use crate::{layout::{Element, Rectangle, Text, Box, model::{styles::{color::{ColorRef, Color as CardboardColor}, stroke::DashPattern, text::{Foreground, Background as TextBackground, Alignment, FlatTextStyle}, font::{Weight, Width}}, elements::image::{Image, Scale}}, PathStyle, Stroke, Solid}, data::{card::Card, project::{Project}}};
 
 use super::{SkiaRendererError, SkiaRenderer};
 
@@ -9,11 +9,12 @@ pub struct CardRenderContext<'a> {
     project: &'a Project,
     dpi: usize,
     renderer: &'a mut SkiaRenderer,
+    base_text_styles: FlatTextStyle<'a>,
 }
 
 impl<'a> CardRenderContext<'a> {
-    pub fn new(card: &'a Card, project: &'a Project, dpi: usize, renderer: &'a mut SkiaRenderer) -> CardRenderContext<'a> {
-        CardRenderContext { card, project, dpi, renderer }
+    pub fn new(card: &'a Card, project: &'a Project, dpi: usize, renderer: &'a mut SkiaRenderer, base_text_styles: FlatTextStyle<'a>) -> CardRenderContext<'a> {
+        CardRenderContext { card, project, dpi, renderer, base_text_styles }
     }
 
     pub fn draw_elements(&mut self, canvas: &mut Canvas, elements: &Vec<Element>, frame_width: usize, frame_height: usize) -> Result<(), miette::Error> {
@@ -131,8 +132,11 @@ impl<'a> CardRenderContext<'a> {
         // https://github.com/davidhollis/cardboard-rs/issues/13
         // TODO(#28): eventually support embedded icons
         // https://github.com/davidhollis/cardboard-rs/issues/28
+
+        let mut text_styles = self.base_text_styles.clone();
+        text_styles.apply(text.style.as_slice());
     
-        if let Some(paragraph_style) = self.compute_text_styles(&text.style)? {
+        if let Some(paragraph_style) = self.compute_text_styles(text_styles)? {
             let mut font_collection = FontCollection::new();
             font_collection.set_default_font_manager(FontMgr::new(), None);
             let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, font_collection);
@@ -228,13 +232,20 @@ impl<'a> CardRenderContext<'a> {
         }
     }
     
-    fn compute_text_styles(&self, styles: &Vec<TextStyle>) -> Result<Option<ParagraphStyle>, miette::Error> {
-        let mut text_style = SkTextStyle::new();
-        let mut text_align = skia_safe::textlayout::TextAlign::Left;
+    fn compute_text_styles(&self, styles: FlatTextStyle<'_>) -> Result<Option<ParagraphStyle>, miette::Error> {
         let mut should_render = true;
         let card_ctx = TryInto::<&handlebars::Context>::try_into(self.card)?;
-    
+        
+        for cond in styles.conditions {
+            should_render = should_render && cond.evaluate(card_ctx)?;
+        }
+        
+        if !should_render {
+            return Ok(None)
+        }
+        
         // Default styles
+        let mut text_style = SkTextStyle::new();
         let mut default_foreground_paint = Paint::new(
             Into::<Color4f>::into(SkiaColor::BLACK),
             None
@@ -243,75 +254,64 @@ impl<'a> CardRenderContext<'a> {
         text_style.set_foreground_color(&default_foreground_paint);
     
         // User-defined styles
-        for style in styles {
-            match style {
-                TextStyle::Font(Font {family, weight, width, style}) => {
-                    text_style.set_font_families(&[family]);
-                    text_style.set_font_style(FontStyle::new(
-                        match weight {
-                            Weight::Thin => skia_safe::font_style::Weight::THIN,
-                            Weight::ExtraLight => skia_safe::font_style::Weight::EXTRA_LIGHT,
-                            Weight::Light => skia_safe::font_style::Weight::LIGHT,
-                            Weight::Normal => skia_safe::font_style::Weight::NORMAL,
-                            Weight::Medium => skia_safe::font_style::Weight::MEDIUM,
-                            Weight::SemiBold => skia_safe::font_style::Weight::SEMI_BOLD,
-                            Weight::Bold => skia_safe::font_style::Weight::BOLD,
-                            Weight::ExtraBold => skia_safe::font_style::Weight::EXTRA_BOLD,
-                            Weight::Black => skia_safe::font_style::Weight::BLACK,
-                            Weight::ExtraBlack => skia_safe::font_style::Weight::EXTRA_BLACK,
-                        },
-                        match width {
-                            Width::UltraCondensed => skia_safe::font_style::Width::ULTRA_CONDENSED,
-                            Width::Condensed => skia_safe::font_style::Width::CONDENSED,
-                            Width::SemiCondensed => skia_safe::font_style::Width::SEMI_CONDENSED,
-                            Width::Normal => skia_safe::font_style::Width::NORMAL,
-                            Width::SemiWide => skia_safe::font_style::Width::SEMI_EXPANDED,
-                            Width::Wide => skia_safe::font_style::Width::EXPANDED,
-                            Width::UltraWide => skia_safe::font_style::Width::ULTRA_EXPANDED,
-                        },
-                        if style == "italic" { Slant::Italic } else { Slant::Upright }
-                    ));
-                },
-                TextStyle::Size(sz) => {
-                    text_style.set_font_size(sz.pixel_size(self.dpi));
-                },
-                TextStyle::Align(Align {alignment}) => {
-                    text_align = match alignment {
-                        Alignment::Left => skia_safe::textlayout::TextAlign::Left,
-                        Alignment::Center => skia_safe::textlayout::TextAlign::Center,
-                        Alignment::Right => skia_safe::textlayout::TextAlign::Right,
-                        Alignment::Justify => skia_safe::textlayout::TextAlign::Justify,
-                    }
-                },
-                TextStyle::Foreground(Foreground {color}) => {
-                    let mut foreground_paint = Paint::new(
-                        Into::<Color4f>::into(self.resolve_color_ref(color)?),
-                        None
-                    );
-                    foreground_paint.set_anti_alias(true);
-                    text_style.set_foreground_color(&foreground_paint);
-                },
-                TextStyle::Background(TextBackground {color}) => {
-                    let mut background_paint = Paint::new(
-                        Into::<Color4f>::into(self.resolve_color_ref(color)?),
-                        None
-                    );
-                    background_paint.set_anti_alias(true);
-                    text_style.set_background_color(&background_paint);
-                },
-                TextStyle::OnlyIf(condition) => {
-                    should_render = should_render && condition.evaluate(card_ctx)?;
-                }
-            }
+        if let Some(family) = styles.font_family {
+            text_style.set_font_families(&[family]);
+        }
+        text_style.set_font_style(FontStyle::new(
+            match styles.font_weight {
+                Weight::Thin => skia_safe::font_style::Weight::THIN,
+                Weight::ExtraLight => skia_safe::font_style::Weight::EXTRA_LIGHT,
+                Weight::Light => skia_safe::font_style::Weight::LIGHT,
+                Weight::Normal => skia_safe::font_style::Weight::NORMAL,
+                Weight::Medium => skia_safe::font_style::Weight::MEDIUM,
+                Weight::SemiBold => skia_safe::font_style::Weight::SEMI_BOLD,
+                Weight::Bold => skia_safe::font_style::Weight::BOLD,
+                Weight::ExtraBold => skia_safe::font_style::Weight::EXTRA_BOLD,
+                Weight::Black => skia_safe::font_style::Weight::BLACK,
+                Weight::ExtraBlack => skia_safe::font_style::Weight::EXTRA_BLACK,
+            },
+            match styles.font_width {
+                Width::UltraCondensed => skia_safe::font_style::Width::ULTRA_CONDENSED,
+                Width::Condensed => skia_safe::font_style::Width::CONDENSED,
+                Width::SemiCondensed => skia_safe::font_style::Width::SEMI_CONDENSED,
+                Width::Normal => skia_safe::font_style::Width::NORMAL,
+                Width::SemiWide => skia_safe::font_style::Width::SEMI_EXPANDED,
+                Width::Wide => skia_safe::font_style::Width::EXPANDED,
+                Width::UltraWide => skia_safe::font_style::Width::ULTRA_EXPANDED,
+            },
+            if styles.font_style == Some("italic") { Slant::Italic } else { Slant::Upright },
+        ));
+        if let Some(size) = styles.size {
+            text_style.set_font_size(size.pixel_size(self.dpi));
+        }
+        let text_align = match styles.align {
+            Alignment::Left => skia_safe::textlayout::TextAlign::Left,
+            Alignment::Center => skia_safe::textlayout::TextAlign::Center,
+            Alignment::Right => skia_safe::textlayout::TextAlign::Right,
+            Alignment::Justify => skia_safe::textlayout::TextAlign::Justify,
+        };
+
+        if let Some(Foreground { color: fg_color }) = styles.foreground {
+            let mut foreground_paint = Paint::new(
+                Into::<Color4f>::into(self.resolve_color_ref(fg_color)?),
+                None
+            );
+            foreground_paint.set_anti_alias(true);
+            text_style.set_foreground_color(&foreground_paint);
+        }
+
+        if let Some(TextBackground { color: bg_color }) = styles.background {
+            let mut background_paint = Paint::new(
+                Into::<Color4f>::into(self.resolve_color_ref(bg_color)?),
+                None
+            );
+            background_paint.set_anti_alias(true);
+            text_style.set_background_color(&background_paint);
         }
     
-        if should_render {
-            let mut paragraph_style = ParagraphStyle::new();
-            paragraph_style.set_text_style(&text_style);
-            paragraph_style.set_text_align(text_align);
-            Ok(Some(paragraph_style))
-        } else {
-            Ok(None)
-        }
+        let mut paragraph_style = ParagraphStyle::new();
+        paragraph_style.set_text_style(&text_style);
+        paragraph_style.set_text_align(text_align);
+        Ok(Some(paragraph_style))
     }
 }

--- a/src/renderer/skia/drawing.rs
+++ b/src/renderer/skia/drawing.rs
@@ -1,6 +1,6 @@
 use skia_safe::{Canvas, Paint, Color4f, IRect, PaintStyle, textlayout::{TextStyle as SkTextStyle, FontCollection, ParagraphBuilder, ParagraphStyle}, FontMgr, Rect, ClipOp, Color as SkiaColor, PathEffect, FontStyle, font_style::Slant};
 
-use crate::{layout::{Element, Rectangle, Text, Box, model::{styles::{color::{ColorRef, Color as CardboardColor}, stroke::DashPattern, text::{Foreground, Background as TextBackground, Alignment, FlatTextStyle}, font::{Weight, Width}}, elements::image::{Image, Scale}}, PathStyle, Stroke, Solid}, data::{card::Card, project::{Project}}};
+use crate::{layout::model::{elements::{Element, shapes::Rectangle, text::Text, containers::Box, image::{Image, Scale}}, styles::{color::{ColorRef, Color as CardboardColor}, stroke::DashPattern, text::{Foreground, Background as TextBackground, Alignment, FlatTextStyle}, font::{Weight, Width}, PathStyle, stroke::Stroke, solid::Solid}}, data::{card::Card, project::{Project}}};
 
 use super::{SkiaRendererError, SkiaRenderer};
 

--- a/src/renderer/skia/drawing.rs
+++ b/src/renderer/skia/drawing.rs
@@ -133,19 +133,17 @@ impl<'a> CardRenderContext<'a> {
         // TODO(#28): eventually support embedded icons
         // https://github.com/davidhollis/cardboard-rs/issues/28
 
-        // If this Text element had a style name specified, look up the style
-        // name in the project config and use that as the base text style.
-        // If there was no style name (or if there was and it wasn't found),
-        // use the base styles from the layout.
-        let mut text_styles =
-            text.style.as_ref()
-            .and_then(|style_name| self.project.style_set_for(style_name))
-            .map(|style_directives| {
-                let mut named_style_set = ComputedTextStyle::default();
-                named_style_set.apply(style_directives);
-                named_style_set
-            })
-            .unwrap_or_else(|| self.base_text_styles.clone());
+        // Build the text styles:
+        // 1. Start with the layout's base styles
+        let mut text_styles = self.base_text_styles.clone();
+
+        // 2. If the Text element has a named style that corresponds to one
+        //    that's in the project's style registry, apply those styles
+        if let Some(named_style) = text.style.as_ref().and_then(|style_name| self.project.style_set_for(style_name)) {
+            text_styles.apply(named_style);
+        }
+
+        // 3. Then apply the inline styles
         text_styles.apply(text.inline_styles.as_slice());
     
         if let Some(paragraph_style) = self.skia_text_styles(text_styles)? {

--- a/src/renderer/skia/mod.rs
+++ b/src/renderer/skia/mod.rs
@@ -4,7 +4,7 @@ use miette::{Diagnostic, IntoDiagnostic};
 use skia_safe::{EncodedImageFormat, PictureRecorder, Rect, Picture, Surface, Image, images, Data};
 use thiserror::Error;
 
-use crate::{data::{project::Project}, config::sheets::{units, layout::Sheet}, layout::model::{geometry::Geometry, styles::text::FlatTextStyle}};
+use crate::{data::{project::Project}, config::sheets::{units, layout::Sheet}, layout::model::{geometry::Geometry, styles::text::ComputedTextStyle, BaseStyles}};
 
 use super::Renderer;
 
@@ -61,9 +61,9 @@ impl Renderer for SkiaRenderer {
         let mut canvas = recorder.begin_recording(bounding_rect, None);
 
         // Draw the card
-        let mut base_text_styles = FlatTextStyle::default();
-        if let Some(ref base_style_definitions) = layout.base_text {
-            base_text_styles.apply(base_style_definitions.styles.as_slice());
+        let mut base_text_styles = ComputedTextStyle::default();
+        if let Some(BaseStyles { text: Some(ref style_definitions), .. }) = layout.base {
+            base_text_styles.apply(style_definitions.styles.as_slice());
         }
         let mut render_ctx = drawing::CardRenderContext::new(card, project, layout.geometry.dpi, self, base_text_styles);
         render_ctx.draw_elements(

--- a/src/renderer/skia/mod.rs
+++ b/src/renderer/skia/mod.rs
@@ -4,7 +4,7 @@ use miette::{Diagnostic, IntoDiagnostic};
 use skia_safe::{EncodedImageFormat, PictureRecorder, Rect, Picture, Surface, Image, images, Data};
 use thiserror::Error;
 
-use crate::{data::{project::Project}, config::sheets::{units, layout::Sheet}, layout::Geometry};
+use crate::{data::{project::Project}, config::sheets::{units, layout::Sheet}, layout::{Geometry, model::styles::text::FlatTextStyle}};
 
 use super::Renderer;
 
@@ -61,7 +61,11 @@ impl Renderer for SkiaRenderer {
         let mut canvas = recorder.begin_recording(bounding_rect, None);
 
         // Draw the card
-        let mut render_ctx = drawing::CardRenderContext::new(card, project, layout.geometry.dpi, self);
+        let mut base_text_styles = FlatTextStyle::default();
+        if let Some(ref base_style_definitions) = layout.base_text {
+            base_text_styles.apply(base_style_definitions.styles.as_slice());
+        }
+        let mut render_ctx = drawing::CardRenderContext::new(card, project, layout.geometry.dpi, self, base_text_styles);
         render_ctx.draw_elements(
             &mut canvas,
             &layout.elements,

--- a/src/renderer/skia/mod.rs
+++ b/src/renderer/skia/mod.rs
@@ -4,7 +4,7 @@ use miette::{Diagnostic, IntoDiagnostic};
 use skia_safe::{EncodedImageFormat, PictureRecorder, Rect, Picture, Surface, Image, images, Data};
 use thiserror::Error;
 
-use crate::{data::{project::Project}, config::sheets::{units, layout::Sheet}, layout::{Geometry, model::styles::text::FlatTextStyle}};
+use crate::{data::{project::Project}, config::sheets::{units, layout::Sheet}, layout::model::{geometry::Geometry, styles::text::FlatTextStyle}};
 
 use super::Renderer;
 


### PR DESCRIPTION
Closes #22 

Adds:
* A `base` element to layouts that expresses common styles that can be overridden by named or inline styles
* A named `text-style` element to project config, expressing common styles that can be selectively applied to `text` elements. Named style sets can override base styles, and can be overridden by inline styles
* A `style` directive for `text` elements in layouts that selects and applies a named style set.