### PR TITLE
Add rudimentary text formatting

### DIFF
--- a/examples/projects/sample/beta.csv
+++ b/examples/projects/sample/beta.csv
@@ -2,3 +2,4 @@ layout,name,rules,picture
 ,"Sample Card B[N]","A normal card from the beta set. This one will be rendered in Palatino, using the default layout. It looks nice enough.",
 fancy,"Sample Card B[F]","A fancy card from the beta set. This one will be rendered in Papyrus, which everyone knows is the fanciest of all typefaces.",
 images,"Image Test Card",,"assets/peppers"
+,"Sample Card B[Fmt]","A normal card, but with a bit of <b><i>wild</i> formatted</b> <i>text</i> in the box. Also has a :symbol: that'll be filled in <red>sometime soon™</red>.",

--- a/examples/render_sample_project.rs
+++ b/examples/render_sample_project.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cardboard::{data::project::Project, renderer::{SkiaRenderer, Renderer}};
+use cardboard::{data::{project::Project, globals}, renderer::{SkiaRenderer, Renderer}};
 use lazy_static::lazy_static;
 use log::LevelFilter;
 use log4rs::{append::console::ConsoleAppender, encode::pattern::PatternEncoder, Config, config::{Appender, Root, Logger}};
@@ -19,12 +19,15 @@ const SAMPLE_DECK: &[(usize, &'static str)] = &[
     (2, "alpha::0002"),
     (3, "alpha_0003"),
     (4, "alpha_0004"),
-    (5, "beta_0003"),
+    (3, "beta_0004"),
+    (2, "beta_0003"),
 ];
 
 fn main() -> miette::Result<()> {
     let verbose = std::env::args().find(|arg| (arg == "-v" || arg == "--verbose")).is_some();
     init_logger(verbose)?;
+
+    globals::init_global_data()?;
 
     let sample_project_dir = format!("{}/examples/projects/sample", BASE_DIR);
     let output_dir = format!("{}/test-renders/sample-project", BASE_DIR);

--- a/src/data/globals.rs
+++ b/src/data/globals.rs
@@ -1,14 +1,41 @@
 use std::{sync::OnceLock, collections::HashMap};
 
-use crate::layout::{model::styles::color::Color, model::Layout};
+use crate::layout::{model::styles::{color::{Color, ColorRef}, TextStyle, font::{Font, Weight}, text::Foreground}, model::Layout, templates::TemplateAwareString};
 
 static BUILTIN_LAYOUTS: OnceLock<HashMap<&'static str, Layout>> = OnceLock::new();
+static BUILTIN_STYLES: OnceLock<HashMap<&'static str, Vec<TextStyle>>> = OnceLock::new();
 
 pub fn init_global_data() -> miette::Result<()> {
     // Explicitly ignore double-initialization, as it should be idempotent
     // TODO(#20): Add some builtin layouts
     // https://github.com/davidhollis/cardboard-rs/issues/20
     let _ = BUILTIN_LAYOUTS.set(HashMap::new());
+
+    let mut style_map = HashMap::new();
+    style_map.insert("b", vec![
+        TextStyle::Font(Font {
+            family: None,
+            weight: Some(Weight::Bold),
+            width: None,
+            style: None,
+        }),
+    ]);
+    style_map.insert("i", vec![
+        TextStyle::Font(Font {
+            family: None,
+            weight: None,
+            width: None,
+            style: Some("italic".to_string()),
+        }),
+    ]);
+    for color in ["black", "dark-gray", "gray", "light-gray", "white", "red", "green", "blue", "yellow", "cyan", "magenta"] {
+        style_map.insert(color, vec![
+            TextStyle::Foreground(Foreground {
+                color: ColorRef::Named(TemplateAwareString::RawString(color.replace("-", " "))),
+            }),
+        ]);
+    }
+
     Ok(())
 }
 
@@ -33,4 +60,10 @@ pub fn color_named(name: &str) -> Option<Color> {
         "magenta" => Some(Color::RGBA(0xff, 0x00, 0xff, 0xff)),
         _ => None,
     }
+}
+
+pub fn style_named(name: &str) -> Option<&'static [TextStyle]> {
+    BUILTIN_STYLES.get()
+        .and_then(|styles| styles.get(name))
+        .map(|style| style.as_slice())
 }

--- a/src/data/globals.rs
+++ b/src/data/globals.rs
@@ -35,6 +35,7 @@ pub fn init_global_data() -> miette::Result<()> {
             }),
         ]);
     }
+    let _ = BUILTIN_STYLES.set(style_map);
 
     Ok(())
 }

--- a/src/data/project.rs
+++ b/src/data/project.rs
@@ -171,7 +171,10 @@ impl Project {
     }
 
     pub fn style_set_for(&self, name: &str) -> Option<&[TextStyle]> {
-        self.text_styles.get(name).map(|v| v.as_slice())
+        self.text_styles
+            .get(name)
+            .map(|v| v.as_slice())
+            .or_else(|| globals::style_named(name))
     }
 
     pub fn layout_named(&self, name: &str) -> Option<&Layout> {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,0 +1,14 @@
+mod parser;
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum FormattedTextInstruction {
+    AddText(String),
+    PushStyle(String),
+    PopStyle(String),
+    InsertPlaceholder(String),
+}
+
+pub fn parse(text: &str) -> Vec<FormattedTextInstruction> {
+    let parser = parser::Parser::new(text);
+    parser.parse()
+}

--- a/src/format/parser.rs
+++ b/src/format/parser.rs
@@ -1,0 +1,202 @@
+use super::FormattedTextInstruction;
+
+const DEFAULT_TAG_BUFFER_SIZE: usize = 24;
+
+pub(super) struct Parser<'a> {
+    text: &'a str,
+    state: ParserState,
+    current_text_buffer: String,
+    current_tag_buffer: String,
+}
+
+impl<'a> Parser<'a> {
+    pub(super) fn new(text: &'a str) -> Parser<'a> {
+        Parser {
+            text,
+            state: ParserState::ReadingText,
+            current_text_buffer: String::new(),
+            current_tag_buffer: String::with_capacity(DEFAULT_TAG_BUFFER_SIZE),
+        }
+    }
+
+    pub(super) fn parse(mut self) -> Vec<FormattedTextInstruction> {
+        let mut instructions = vec![];
+
+        for ch in self.text.chars() {
+            match self.state {
+                ParserState::ReadingText => match ch {
+                    '<' => self.state = ParserState::ReadingStyleTag,
+                    ':' => self.state = ParserState::ReadingPlaceholderSigil,
+                    _ => self.current_text_buffer.push(ch),
+                },
+                ParserState::ReadingStyleTag => match ch {
+                    ('A' ..= 'Z') | ('a' ..= 'z') | ('0' ..= '9') | '.' | '_' | '-' => {
+                        self.current_tag_buffer.push(ch);
+                        self.state = ParserState::ReadingStyleOpenTag;
+                    },
+                    '/' => self.state = ParserState::ReadingStyleCloseTag,
+                    _ => {
+                        // Abandon parsing a tag. Push the '<' we've already
+                        // read and the character we're looking at.
+                        self.current_text_buffer.push('<');
+                        self.current_text_buffer.push(ch);
+                        self.state = ParserState::ReadingText;
+                    },
+                },
+                ParserState::ReadingStyleOpenTag => match ch {
+                    ('A' ..= 'Z') | ('a' ..= 'z') | ('0' ..= '9') | '.' | '_' | '-' => {
+                        self.current_tag_buffer.push(ch)
+                    },
+                    '>' => {
+                        // Finish reading the tag
+                        if !self.current_text_buffer.is_empty() {
+                            instructions.push(FormattedTextInstruction::AddText(self.current_text_buffer));
+                            self.current_text_buffer = String::new();
+                        }
+                        instructions.push(FormattedTextInstruction::PushStyle(self.current_tag_buffer));
+                        self.current_tag_buffer = String::with_capacity(DEFAULT_TAG_BUFFER_SIZE);
+                        self.state = ParserState::ReadingText;
+                    },
+                    _ => {
+                        // Abandon parsing a tag. Push the '<' we've already
+                        // read, the "tag name" we've read so far, and the
+                        // character we're looking at.
+                        self.current_text_buffer.push('<');
+                        self.current_text_buffer.push_str(&self.current_tag_buffer);
+                        self.current_text_buffer.push(ch);
+                        self.current_tag_buffer = String::with_capacity(DEFAULT_TAG_BUFFER_SIZE);
+                        self.state = ParserState::ReadingText;
+                    },
+                },
+                ParserState::ReadingStyleCloseTag => match ch {
+                    ('A' ..= 'Z') | ('a' ..= 'z') | ('0' ..= '9') | '.' | '_' | '-' => {
+                        self.current_tag_buffer.push(ch)
+                    },
+                    '>' => {
+                        if self.current_tag_buffer.is_empty() {
+                            // Empty "close tags" ("</>") aren't actually tags
+                            self.current_text_buffer.push_str("</>");
+                            self.state = ParserState::ReadingText;
+                        } else {
+                            // Finish reading the tag
+                            if !self.current_text_buffer.is_empty() {
+                                instructions.push(FormattedTextInstruction::AddText(self.current_text_buffer));
+                                self.current_text_buffer = String::new();
+                            }
+                            instructions.push(FormattedTextInstruction::PopStyle(self.current_tag_buffer));
+                            self.current_tag_buffer = String::with_capacity(DEFAULT_TAG_BUFFER_SIZE);
+                            self.state = ParserState::ReadingText;
+                        }
+                    },
+                    _ => {
+                        // Abandon parsing a tag. Push the '</' we've already
+                        // read, the "tag name" we've read so far, and the
+                        // character we're looking at.
+                        self.current_text_buffer.push_str("</");
+                        self.current_text_buffer.push_str(&self.current_tag_buffer);
+                        self.current_text_buffer.push(ch);
+                        self.current_tag_buffer = String::with_capacity(DEFAULT_TAG_BUFFER_SIZE);
+                        self.state = ParserState::ReadingText;
+                    },
+                },
+                ParserState::ReadingPlaceholderSigil => match ch {
+                    ('A' ..= 'Z') | ('a' ..= 'z') | ('0' ..= '9') | '/' | '.' | '_' | '-' => {
+                        self.current_tag_buffer.push(ch)
+                    },
+                    ':' => {
+                        if self.current_tag_buffer.is_empty() {
+                            // Empty "placeholders" ("::") aren't actually placeholders
+                            self.current_text_buffer.push_str("::");
+                            self.state = ParserState::ReadingText;
+                        } else {
+                            // Finish reading the placeholder
+                            if !self.current_text_buffer.is_empty() {
+                                instructions.push(FormattedTextInstruction::AddText(self.current_text_buffer));
+                                self.current_text_buffer = String::new();
+                            }
+                            instructions.push(FormattedTextInstruction::InsertPlaceholder(self.current_tag_buffer));
+                            self.current_tag_buffer = String::with_capacity(DEFAULT_TAG_BUFFER_SIZE);
+                            self.state = ParserState::ReadingText;
+                        }
+                    },
+                    _ => {
+                        // Abandon parsing a placeholder. Push the ':' we've
+                        // already read, the "placeholder name" we've read so
+                        // far, and the character we're looking at.
+                        self.current_text_buffer.push(':');
+                        self.current_text_buffer.push_str(&self.current_tag_buffer);
+                        self.current_text_buffer.push(ch);
+                        self.current_tag_buffer = String::with_capacity(DEFAULT_TAG_BUFFER_SIZE);
+                        self.state = ParserState::ReadingText;
+                    },
+                },
+            }
+        }
+
+        if !self.current_text_buffer.is_empty() {
+            instructions.push(FormattedTextInstruction::AddText(self.current_text_buffer));
+        }
+
+        instructions
+    }
+}
+
+enum ParserState {
+    ReadingText,
+    ReadingStyleTag,
+    ReadingStyleOpenTag,
+    ReadingStyleCloseTag,
+    ReadingPlaceholderSigil,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::format::FormattedTextInstruction;
+
+    use super::Parser;
+
+    #[test]
+    fn it_finds_well_formed_elements() -> () {
+        let text = "Some text with <b>nested <i>tags</i></b> and even an :emoji: for good measure";
+        let parser = Parser::new(text);
+        let formatting_instructions = parser.parse();
+
+        assert_eq!(
+            formatting_instructions,
+            vec![
+                FormattedTextInstruction::AddText("Some text with ".to_string()),
+                FormattedTextInstruction::PushStyle("b".to_string()),
+                FormattedTextInstruction::AddText("nested ".to_string()),
+                FormattedTextInstruction::PushStyle("i".to_string()),
+                FormattedTextInstruction::AddText("tags".to_string()),
+                FormattedTextInstruction::PopStyle("i".to_string()),
+                FormattedTextInstruction::PopStyle("b".to_string()),
+                FormattedTextInstruction::AddText(" and even an ".to_string()),
+                FormattedTextInstruction::InsertPlaceholder("emoji".to_string()),
+                FormattedTextInstruction::AddText(" for good measure".to_string()),
+            ]
+        )
+    }
+
+    #[test]
+    fn it_degrades_invalid_forms_to_text() -> () {
+        let text = r###"
+            This should just be one big text instruction:
+              - open tag <with spaces>
+              - close tag </with spaces>
+              - emoji :with spaces:
+              - empty open tag <>,
+              - empty close tag </>
+              - empty emoji ::
+        "###;
+        let parser = Parser::new(text);
+        let instructions = parser.parse();
+
+        assert_eq!(
+            instructions,
+            vec![
+                FormattedTextInstruction::AddText(text.to_string()),
+            ]
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod data;
+pub mod format;
 pub mod layout;
 pub mod renderer;


### PR DESCRIPTION
Adds a very simple markup language to the text renderer. It has HTML-like `<tag>`s but there's no notion of tag attributes or anything like that. Any named style provided in the project config (or the global defaults) automatically becomes a tag, so something like

```kdl
text-style "reminder" {
    font style="italic"
    foreground "dark gray"
}
```

makes a tag `<reminder>(this is reminder text)</reminder>` available to all `text` elements in the project. Tags are nestable and override only the style attributes they specify (so `<b><i>bold and italic text</i></b>` works like you expect). There are a few global tags:

  * `<b>`, which bolds the enclosed text
  * `<i>`, which italicizes the enclosed text
  * `<COLOR>` for every builtin COLOR (e.g., `<blue>`), which changes the foreground color

Formatting is applied after template filling, so partial bits of text don't have to be well-formed on their own.

Closes #13 