### PR TITLE
Add support for image placeholders

### DIFF
--- a/examples/projects/sample/beta.csv
+++ b/examples/projects/sample/beta.csv
@@ -2,4 +2,5 @@ layout,name,rules,picture
 ,"Sample Card B[N]","A normal card from the beta set. This one will be rendered in Palatino, using the default layout. It looks nice enough.",
 fancy,"Sample Card B[F]","A fancy card from the beta set. This one will be rendered in Papyrus, which everyone knows is the fanciest of all typefaces.",
 images,"Image Test Card",,"assets/peppers"
+images,"Placeholder Test Card",,"no-such-image"
 ,"Sample Card B[Fmt]","A normal card, but with a bit of <b><i>wild</i> formatted</b> <i>text</i> in the box. Also has a :symbol: that'll be filled in <red>sometime soon™</red>.",

--- a/examples/render_sample_project.rs
+++ b/examples/render_sample_project.rs
@@ -19,7 +19,7 @@ const SAMPLE_DECK: &[(usize, &'static str)] = &[
     (2, "alpha::0002"),
     (3, "alpha_0003"),
     (4, "alpha_0004"),
-    (3, "beta_0004"),
+    (3, "beta_0005"),
     (2, "beta_0003"),
 ];
 


### PR DESCRIPTION
Now, when an image name doesn't resolve appropriately, we draw a placeholder instead of bailing.